### PR TITLE
Implement remove downloaded JDK command

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use log::debug;
+use std::path::Path;
 
 pub(crate) fn extract_java_version<E>(
     mut lines: impl Iterator<Item = Result<String, E>>,
@@ -31,4 +32,14 @@ pub(crate) fn extract_java_version<E>(
             Some(Ok(value.to_string()))
         })
         .transpose()
+}
+
+pub(crate) fn is_symlink<P: AsRef<Path>>(symlink: P) -> bool {
+    // This is a copy of std::path::Path::is_symlink()
+    // currently marked unstable, but the parts that make up the function aren't
+    return symlink
+        .as_ref()
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
 }


### PR DESCRIPTION
This command has 2 modes, standard and force. Standard is the default,
and requires user-input to confirm deleting the selected directories is
okay. Force mode skips confirmation and can be done unattended.

Force mode can also be "faked" with this common bash-ism:
```
yes | jpre remove <jdk_version>
```

If the JDK selected for removal is the JDK currently in use, then the
symlink will also be removed, to prevent broken symlinks.