### PR TITLE
Implement 'available' sub-command, add support for aarch64

### DIFF
--- a/src/api/adoptium.rs
+++ b/src/api/adoptium.rs
@@ -117,7 +117,7 @@ fn get_os_name() -> JdkFetchResult<&'static str> {
 fn get_arch_name() -> JdkFetchResult<&'static str> {
     let env_arch = std::env::consts::ARCH;
     match env_arch {
-        "x86" => Ok(env_arch),
+        "x86" | "aarch64" => Ok(env_arch),
         "x86_64" => Ok("x64"),
         _ => Err(JdkFetchError::Incompatible {
             message: format!("Unsupported architecture: {}", env_arch),

--- a/src/api/def.rs
+++ b/src/api/def.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -20,4 +21,6 @@ pub trait JdkFetchApi {
     /// Get the latest JDK version, returning `None` if the API doesn't know about this major
     /// version.
     fn get_latest_jdk_version(&self, major: u8) -> JdkFetchResult<Option<String>>;
+
+    fn get_available_jdk_versions(&self) -> JdkFetchResult<HashSet<String>>;
 }

--- a/src/api/def.rs
+++ b/src/api/def.rs
@@ -6,6 +6,8 @@ pub enum JdkFetchError {
     HttpIo(#[from] attohttpc::Error),
     #[error("error from upstream: {message}")]
     Upstream { message: String },
+    #[error("{message}")]
+    Incompatible { message: String },
     #[error("unknown error: {message}")]
     Generic { message: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,36 @@ fn check_env_bound(jdk_manager: &JdkManager<AdoptiumApi>) -> Result<()> {
     Ok(())
 }
 
+fn is_unsupported_system() -> bool {
+    let env_os = std::env::consts::OS;
+    match env_os {
+        "linux" | "macos" => {}
+        _ => {
+            eprintln!("{}", format!("jpre does not support OS: {}", env_os).red());
+            return true;
+        }
+    }
+
+    let env_arch = std::env::consts::ARCH;
+    match env_arch {
+        "x86" | "x86_64" => {}
+        _ => {
+            eprintln!(
+                "{}",
+                format!("jpre does not support architecture: {}", env_arch).red()
+            );
+            return true;
+        }
+    }
+
+    false
+}
+
 fn main() {
+    if is_unsupported_system() {
+        return;
+    }
+
     let args: Jpre = Jpre::from_args();
     if let Err(error) = main_for_result(args) {
         eprintln!("{}", format!("Error: {:?}", error).red());

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn is_unsupported_system() -> bool {
 
     let env_arch = std::env::consts::ARCH;
     match env_arch {
-        "x86" | "x86_64" => {}
+        "x86" | "x86_64" | "aarch64" => {}
         _ => {
             eprintln!(
                 "{}",


### PR DESCRIPTION
The `available` subcommand queries the API to return a list of major JDK versions which could be downloaded and installed from the chosen host.

This includes a commit which moves some stuff around to make the above change easier, but also to provide some nicer error messages for unsupported systems or unavailable versions.

Adding aarch64 support allows this to work correctly on M1 macOS as well.